### PR TITLE
Use Array for origin in CorsOptions, rather than function

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,20 +12,13 @@ import position from './routes/position';
 
 const app = express();
 
-const allowed = [
-  'https://brickwall.csh.rit.edu',
-  'http://localhost:8080',
-  'http://localhost:3000'
-];
 const corsOptions: CorsOptions = {
   optionsSuccessStatus: 204,
-  origin: function (origin, callback) {
-    if (origin && allowed.indexOf(origin) !== -1) {
-      callback(null, true);
-    } else {
-      callback(new Error('Not allowed by CORS'));
-    }
-  }
+  origin: [
+    'https://brickwall.csh.rit.edu',
+    'http://localhost:8080',
+    'http://localhost:3000'
+  ]
 };
 
 app.use(cors(corsOptions));


### PR DESCRIPTION
It seems like the function was implemented to allow for multiple origins, but there's bulit-in support to use an array for multiple origins.